### PR TITLE
`🚀feat(worker-delegator)`: new WorkerDelegator

### DIFF
--- a/lib/src/flutter_constants.dart
+++ b/lib/src/flutter_constants.dart
@@ -1,0 +1,4 @@
+const bool isWeb = identical(1, 1.0);
+const bool isReleaseMode = bool.fromEnvironment('dart.vm.product');
+const bool isProfileMode = bool.fromEnvironment('dart.vm.profile');
+const bool isDebugMode = !isReleaseMode && !isProfileMode;

--- a/lib/src/worker_delegator/default_delegate.dart
+++ b/lib/src/worker_delegator/default_delegate.dart
@@ -1,0 +1,25 @@
+import 'dart:async' show FutureOr;
+
+/// A delegate for when running on Dart VM.
+abstract class DefaultDelegate<Q, R> {
+  /// Creates a [DefaultDelegate] with a single argument [callback] to be called
+  /// when running on Dart VM.
+  const factory DefaultDelegate({
+    required FutureOr<R> Function(Q message) callback,
+  }) = _SingleArgumentDefaultDelegate<Q, R>;
+
+  /// The callback that will be called when the app is running
+  /// on Dart VM (Android, iOS, macOS, etc).
+  ///
+  /// This must be a top-level function.
+  FutureOr<R> Function(Q message) get callback;
+}
+
+class _SingleArgumentDefaultDelegate<Q, R> implements DefaultDelegate<Q, R> {
+  const _SingleArgumentDefaultDelegate({
+    required this.callback,
+  });
+
+  @override
+  final FutureOr<R> Function(Q message) callback;
+}

--- a/lib/src/worker_delegator/js_delegate.dart
+++ b/lib/src/worker_delegator/js_delegate.dart
@@ -1,0 +1,36 @@
+/// A delegate for when running on Web.
+abstract class JsDelegate {
+  /// Creates a [JsDelegate] with a single argument [callback] to be
+  /// called when running on Web.
+  ///
+  /// [callback] must be either a [String] or a [List] of [String].
+  const factory JsDelegate({
+    required dynamic callback,
+    Future<dynamic> Function()? fallback,
+  }) = _SingleDynamicArgumentJsDelegate;
+
+  /// The callback name declared in the web worker.
+  /// This should either be a [String] or a [List] of [String],
+  /// otherwise it will throw [AssertionError] on debug mode.
+  dynamic get callback;
+
+  /// The fallback function that will be called by JsIsolatedWorker
+  /// when Web Worker is not available on the user's browser.
+  Future<dynamic> Function()? get fallback;
+}
+
+class _SingleDynamicArgumentJsDelegate implements JsDelegate {
+  const _SingleDynamicArgumentJsDelegate({
+    required this.callback,
+    this.fallback,
+  }) : assert(
+          callback is String || callback is List<String>,
+          '$callback is not compatible with type `String` or `List<String>`',
+        );
+
+  @override
+  final dynamic callback;
+
+  @override
+  final Future<dynamic> Function()? fallback;
+}

--- a/lib/src/worker_delegator/worker_delegate.dart
+++ b/lib/src/worker_delegator/worker_delegate.dart
@@ -1,0 +1,60 @@
+import '../flutter_constants.dart';
+import 'default_delegate.dart';
+import 'js_delegate.dart';
+
+/// A worker delegate for both Dart's Isolate and Web Worker.
+abstract class WorkerDelegate<Q, R> {
+  /// Creates a new [WorkerDelegate] that consists of its [key],
+  /// [defaultDelegate] for when running on Dart VM, and
+  /// [jsDelegate] for when running on Web.
+  const factory WorkerDelegate({
+    required Object key,
+    required DefaultDelegate<Q, R> defaultDelegate,
+    required JsDelegate jsDelegate,
+  }) = _AdaptiveWorkerDelegate<Q, R>;
+
+  /// The key associated to this [WorkerDelegate].
+  Object get key;
+
+  /// The delegate for when running on Dart VM.
+  ///
+  /// This will be null when running on Web.
+  JsDelegate get jsDelegate;
+
+  /// The delegate for when running on Web.
+  ///
+  /// This will be null when running on Dart VM.
+  DefaultDelegate<Q, R> get defaultDelegate;
+}
+
+class _AdaptiveWorkerDelegate<Q, R> implements WorkerDelegate<Q, R> {
+  const _AdaptiveWorkerDelegate({
+    required this.key,
+    required DefaultDelegate<Q, R> defaultDelegate,
+    required JsDelegate jsDelegate,
+  })  : _jsDelegate = isWeb ? jsDelegate : null,
+        _defaultDelegate = isWeb ? null : defaultDelegate;
+
+  @override
+  final Object key;
+
+  final DefaultDelegate<Q, R>? _defaultDelegate;
+
+  @override
+  DefaultDelegate<Q, R> get defaultDelegate {
+    if (_defaultDelegate != null) {
+      return _defaultDelegate!;
+    }
+    throw UnsupportedError('defaultDelegate');
+  }
+
+  final JsDelegate? _jsDelegate;
+
+  @override
+  JsDelegate get jsDelegate {
+    if (_jsDelegate != null) {
+      return _jsDelegate!;
+    }
+    throw UnsupportedError('jsDelegate');
+  }
+}

--- a/lib/src/worker_delegator/worker_delegator.dart
+++ b/lib/src/worker_delegator/worker_delegator.dart
@@ -1,0 +1,48 @@
+import '../flutter_constants.dart';
+import '../isolated_worker_default.dart';
+import '../isolated_worker_web.dart';
+import 'worker_delegate.dart';
+
+part 'worker_delegator_impl.dart';
+
+/// A class helping for easier bridging between
+/// [IsolatedWorker] and [JsIsolatedWorker].
+///
+/// It will call [WorkerDelegate.defaultDelegate] when running on Dart VM.
+///
+/// When running on Web, it will call [WorkerDelegate.jsDelegate] instead.
+abstract class WorkerDelegator {
+  /// Returns a singleton instance of [WorkerDelegator]
+  factory WorkerDelegator() => _WorkerDelegatorImpl._instance;
+
+  /// Executes [JsIsolatedWorker.importScripts] when running on Web.
+  ///
+  /// If it's running on Dart VM, this will always return `true`.
+  Future<bool> importScripts(List<String> scripts);
+
+  /// Adds a new [WorkerDelegate] with its [WorkerDelegate.key].
+  ///
+  /// Each [delegate] should have its unique key, meaning two or more
+  /// [WorkerDelegate] with the same key cannot be added. Otherwise it will
+  /// throw [AssertionError] on debug mode.
+  void addDelegate<Q, R>(WorkerDelegate<Q, R> delegate);
+
+  /// Adds new multiple [WorkerDelegate]s.
+  ///
+  /// Each of the [delegates] should have its unique key, meaning two or more
+  /// [WorkerDelegate] with the same key cannot be added. Otherwise it will
+  /// throw [AssertionError] on debug mode.
+  void addAllDelegates<Q, R>(Iterable<WorkerDelegate<Q, R>> delegates);
+
+  /// Executes a callback that is associated with the [key].
+  ///
+  /// If no [WorkerDelegate] with [key] found, this will throw [ArgumentError].
+  Future<R> run<Q, R>(Object key, dynamic message);
+
+  /// Closes the worker.
+  ///
+  /// If it's running on Dart VM, it will call [IsolatedWorker.close].
+  ///
+  /// If it's running on Web, it will call [JsIsolatedWorker.close].
+  void close();
+}

--- a/lib/src/worker_delegator/worker_delegator_impl.dart
+++ b/lib/src/worker_delegator/worker_delegator_impl.dart
@@ -1,0 +1,79 @@
+part of 'worker_delegator.dart';
+
+class _WorkerDelegatorImpl implements WorkerDelegator {
+  const _WorkerDelegatorImpl({
+    required Map<Object, WorkerDelegate> delegates,
+  }) : _delegates = delegates;
+
+  // We don't want the [_delegates] to be unmodifiable.
+  // ignore: prefer_const_constructors
+  static final _WorkerDelegatorImpl _instance = _WorkerDelegatorImpl(
+    delegates: <Object, WorkerDelegate>{},
+  );
+
+  final Map<Object, WorkerDelegate> _delegates;
+
+  @override
+  Future<bool> importScripts(List<String> scripts) {
+    if (isWeb) {
+      return JsIsolatedWorker().importScripts(scripts);
+    }
+
+    return Future<bool>.value(true);
+  }
+
+  @override
+  void addAllDelegates<Q, R>(Iterable<WorkerDelegate<Q, R>> delegates) {
+    for (final WorkerDelegate delegate in delegates) {
+      addDelegate(delegate);
+    }
+  }
+
+  @override
+  void addDelegate<Q, R>(WorkerDelegate<Q, R> delegate) {
+    assert(
+      !_delegates.containsKey(delegate.key),
+      'WorkerDelegate of "${delegate.key}" already exists!',
+    );
+    _delegates[delegate.key] = delegate;
+  }
+
+  @override
+  Future<R> run<Q, R>(Object key, dynamic message) async {
+    final WorkerDelegate<Q, R>? delegate =
+        _delegates[key] as WorkerDelegate<Q, R>?;
+    if (delegate == null) {
+      if (isDebugMode || isProfileMode) {
+        throw ArgumentError(
+          'No WorkerDelegate with key "$key" found!',
+          'key',
+        );
+      }
+      throw ArgumentError(
+        'Not found',
+        'key',
+      );
+    }
+    if (isWeb) {
+      return await JsIsolatedWorker().run(
+        functionName: delegate.jsDelegate.callback,
+        arguments: message,
+        fallback: delegate.jsDelegate.fallback,
+      ) as R;
+    }
+
+    return IsolatedWorker().run<Q, R>(
+      delegate.defaultDelegate.callback,
+      message as Q,
+    );
+  }
+
+  @override
+  void close() {
+    if (isWeb) {
+      JsIsolatedWorker().close();
+      return;
+    }
+    IsolatedWorker().close();
+  }
+}

--- a/lib/worker_delegator.dart
+++ b/lib/worker_delegator.dart
@@ -1,0 +1,4 @@
+export 'src/worker_delegator/default_delegate.dart';
+export 'src/worker_delegator/js_delegate.dart';
+export 'src/worker_delegator/worker_delegate.dart';
+export 'src/worker_delegator/worker_delegator.dart';

--- a/test/isolated_worker_test.dart
+++ b/test/isolated_worker_test.dart
@@ -1,4 +1,5 @@
 import 'package:isolated_worker/isolated_worker.dart';
+import 'package:isolated_worker/worker_delegator.dart';
 import 'package:test/test.dart';
 
 List<int> isolatedWork(int number) {
@@ -6,11 +7,11 @@ List<int> isolatedWork(int number) {
 }
 
 void main() {
-  group('Test [IsolatedWorker]\n', () {
-    tearDownAll(() {
-      IsolatedWorker().close();
-    });
+  tearDownAll(() {
+    IsolatedWorker().close();
+  });
 
+  group('Test [IsolatedWorker]\n', () {
     test(
         'Verify [isolatedWork] running with [IsolatedWorker]\n'
         'returns a List of integers containing 1 to 9', () {
@@ -97,6 +98,42 @@ void main() {
           containsAllInOrder(Iterable.generate(25, (n) => n + 1)),
         );
       });
+    });
+  });
+
+  group('Test [WorkerDelegator] on Dart VM\n', () {
+    setUpAll(() {
+      const JsDelegate dummyJsDelegate = JsDelegate(callback: 'callback');
+
+      const DefaultDelegate<int, List<int>> dummyDefDelegate =
+          DefaultDelegate<int, List<int>>(callback: isolatedWork);
+
+      const WorkerDelegate<int, List<int>> dummyWorkerDelegate =
+          WorkerDelegate<int, List<int>>(
+        key: 'dummy1to9',
+        defaultDelegate: dummyDefDelegate,
+        jsDelegate: dummyJsDelegate,
+      );
+
+      WorkerDelegator().addDelegate(dummyWorkerDelegate);
+    });
+
+    test(
+        'Verify [isolatedWork] running with [WorkerDelegator]\n'
+        'returns a List of integers containing 1 to 9\n', () {
+      expectLater(
+        WorkerDelegator().run<int, List<int>>('dummy1to9', 9).then(
+          (value) {
+            expect(value, isA<List<int>>());
+
+            expect(
+              value,
+              containsAllInOrder(Iterable.generate(9, (n) => n + 1)),
+            );
+          },
+        ),
+        completes,
+      );
     });
   });
 }


### PR DESCRIPTION
New `WorkerDelegator` works as a bridge between `IsolatedWorker` and `JsIsolatedWorker`. Hopefully with this new feature, user can use both `IsolatedWorker` and `JsIsolatedWorker` easier and cleaner.