### PR TITLE
fix(isolated-worker-default): fix late init error on close

### DIFF
--- a/lib/src/isolated_worker_default.dart
+++ b/lib/src/isolated_worker_default.dart
@@ -15,5 +15,5 @@ abstract class IsolatedWorker {
   );
 
   /// Don't try to [close] when the app still needs the [run] function
-  void close();
+  FutureOr<void> close();
 }

--- a/lib/src/isolated_worker_default_impl.dart
+++ b/lib/src/isolated_worker_default_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show Completer, FutureOr, StreamSubscription;
 import 'dart:collection' show LinkedHashMap;
 import 'dart:isolate' show Isolate, ReceivePort, SendPort;
+import 'package:meta/meta.dart';
 
 import 'isolated_worker_default.dart';
 
@@ -81,6 +82,10 @@ class _ResultErrorMessage implements _CallbackObject {
 
 class IsolatedWorkerImpl implements IsolatedWorker {
   factory IsolatedWorkerImpl() => _instance;
+
+  @internal
+  @visibleForTesting
+  factory IsolatedWorkerImpl.create() => IsolatedWorkerImpl._();
 
   /// it's important to call [IsolatedWorkerImpl._init] first
   /// before running any operations using [IsolatedWorkerImpl.run]

--- a/lib/src/isolated_worker_default_impl.dart
+++ b/lib/src/isolated_worker_default_impl.dart
@@ -183,11 +183,13 @@ class IsolatedWorkerImpl implements IsolatedWorker {
 }
 
 void _workerEntryPoint(final SendPort parentSendPort) {
-  _Worker(parentSendPort).init();
+  _Worker(parentSendPort);
 }
 
 class _Worker {
-  _Worker(this.parentSendPort);
+  _Worker(this.parentSendPort) {
+    _init();
+  }
 
   /// this is used to listen messages sent by [IsolatedWorker]
   ///
@@ -199,7 +201,7 @@ class _Worker {
 
   late final StreamSubscription<dynamic> _parentMessages;
 
-  void init() {
+  void _init() {
     _parentMessages = _receivePort.listen(_parentMessageReceiver);
 
     parentSendPort.send(_receivePort.sendPort);

--- a/lib/src/isolated_worker_default_impl.dart
+++ b/lib/src/isolated_worker_default_impl.dart
@@ -173,9 +173,10 @@ class IsolatedWorkerImpl implements IsolatedWorker {
   }
 
   @override
-  void close() {
+  Future<void> close() async {
     /// tell [_Worker] to call _dispose()
-    _workerSendPort.then((sendPort) => sendPort.send(false));
+    final SendPort sendPort = await _workerSendPort;
+    sendPort.send(false);
     _workerMessages.cancel();
     _receivePort.close();
     _isolate.kill();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: 1.7.0
+  meta: ^1.7.0
 
 dev_dependencies:
   lint: ^1.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,9 @@ issue_tracker: https://www.github.com/iandis/isolated_worker/issues
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+dependencies:
+  meta: 1.7.0
+
 dev_dependencies:
   lint: ^1.6.0
   test: ^1.16.0

--- a/test/isolated_worker_test.dart
+++ b/test/isolated_worker_test.dart
@@ -1,9 +1,14 @@
 import 'package:isolated_worker/isolated_worker.dart';
+import 'package:isolated_worker/src/isolated_worker_default_impl.dart';
 import 'package:isolated_worker/worker_delegator.dart';
 import 'package:test/test.dart';
 
 List<int> isolatedWork(int number) {
   return List<int>.generate(number, (index) => index + 1);
+}
+
+Future<void> delayedFunc([void noArgs]) {
+  return Future<void>.delayed(const Duration(seconds: 2));
 }
 
 void main() {
@@ -99,6 +104,19 @@ void main() {
         );
       });
     });
+
+    test(
+      'Verify closing [IsolatedWorker] immediately after calling [IsolatedWorker.run] '
+      'should not throw LateInitializationError',
+      () {
+        final IsolatedWorker isolatedWorker = IsolatedWorkerImpl.create();
+        isolatedWorker.run(delayedFunc, null);
+        expect(
+          isolatedWorker.close(),
+          completes,
+        );
+      },
+    );
   });
 
   group('Test [WorkerDelegator] on Dart VM\n', () {


### PR DESCRIPTION
This fixes #13 

The error occurs on `IsolatedWorkerImpl.close` because the Isolate was not given a chance to warm up, making it throw `LateInitializationError` (because the Isolate object hasn't been created). This PR fixes it by awaiting the main `SendPort` to receive the child `SendPort` first so that the Isolate object can be created thus can be closed.